### PR TITLE
fix: corrige les 2 alertes sécurité (org.json DoS + permissions workflow)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# This workflow only SSHes into the server; it never uses the GITHUB_TOKEN,
+# so grant it no permissions at all (principle of least privilege).
+permissions: {}
+
 concurrency:
   group: deploy-api
   cancel-in-progress: false

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20230227</version>
+            <version>20250517</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.vaadin.external.google</groupId>


### PR DESCRIPTION
## Contexte

Corrige les 2 alertes sécurité ouvertes sur `jimi_api`.

| Source | Sévérité | Sujet | Fichier |
|--------|----------|-------|---------|
| [Dependabot #1](https://github.com/JIMIDevLab/jimi_api/security/dependabot/1) | HIGH | DoS dans `org.json` (CVE-2023-5072) | `pom.xml` |
| [Code Scanning #1](https://github.com/JIMIDevLab/jimi_api/security/code-scanning/1) | MEDIUM | `actions/missing-workflow-permissions` | `.github/workflows/deploy.yml` |

## Changements

1. **`org.json:json`** : `20230227` → `20250517` (dernière stable, > seuil corrigé `20231013`). API compatible, aucun changement de code. `./mvnw compile` ✅
2. **`deploy.yml`** : ajout d'un bloc `permissions: {}`. Le workflow ne fait que du SSH et n'utilise jamais le `GITHUB_TOKEN` → moindre privilège.

🤖 Generated with [Claude Code](https://claude.com/claude-code)